### PR TITLE
Add package init and TensorFlow optional import in tests

### DIFF
--- a/test_seed.py
+++ b/test_seed.py
@@ -2,6 +2,9 @@ import os, math, time, random
 # Disable oneDNN custom operations
 os.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'
 
+import pytest
+pytest.importorskip("tensorflow")
+
 import tensorflow as tf
 # force a single OpenMP thread to avoid the MKL memory-leak warning
 os.environ["OMP_NUM_THREADS"] = "1"


### PR DESCRIPTION
## Summary
- add empty module initializer so `src` is importable
- gracefully skip `test_seed.py` when TensorFlow isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fbbe48c8832bb676af0356c9a6e5